### PR TITLE
Fixes an issue with sending messages that does not need to be compres…

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/EventDataExtensions.cs
+++ b/src/Serilog.Sinks.AzureEventHub/EventDataExtensions.cs
@@ -43,6 +43,9 @@ namespace Serilog
                 PartitionKey = Guid.NewGuid().ToString()
             };
 
+            foreach (var eventDataProperty in eventData.Properties)
+                compressedEventData.Properties.Add(eventDataProperty);
+
             compressedEventData.Properties.Add(CONTENT_ENCODING, GZIP);
             return compressedEventData;
         }

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>CollectorBank.Serilog.Sinks.AzureEventHub</id>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <authors>Ben Gale, Adam Lith, Mats Iremark </authors>
     <description>Serilog event sink that writes to Azure Event Hubs.</description>
     <language>en-US</language>

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
@@ -71,10 +71,10 @@ namespace Serilog.Sinks.AzureEventHub
                 PartitionKey = Guid.NewGuid().ToString()
             };
 
+            _eventDataAction?.Invoke(eventHubData, logEvent);
+
             if (_compressionTreshold != null && eventHubData.SerializedSizeInBytes > _compressionTreshold)
                 eventHubData = eventHubData.AsCompressed();
-
-            _eventDataAction?.Invoke(eventHubData, logEvent);
 
             using (var transaction = new TransactionScope(TransactionScopeOption.Suppress))
             {


### PR DESCRIPTION
…sed. The issue was that you can not add properties to an EventData object after you have accessed its SerializedSizeInBytes property.