### PR TITLE
Remove type and application name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/qhv5yfucxj456a8d/branch/master?svg=true)](https://ci.appveyor.com/project/CollectorHeimdal/serilog-sinks-azureeventhub/branch/master)
 
 A Serilog sink that writes events to Azure EventHubs
+
+##Usage
+
+```csharp
+var eventHubClient = EventHubClient.CreateFromConnectionString(eventHubConnectionString, "entityPath");
+var logger = new LoggerConfiguration()
+                .WriteTo.Sink(new AzureEventHubSink(
+                    eventHubClient: eventHubClient,
+                    formatter: new JsonFormatter()
+                    )
+				...
+				.CreateLogger();
+					
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ var eventHubClient = EventHubClient.CreateFromConnectionString(eventHubConnectio
 var logger = new LoggerConfiguration()
                 .WriteTo.Sink(new AzureEventHubSink(
                     eventHubClient: eventHubClient,
-                    formatter: new JsonFormatter()
                 ...
                 .CreateLogger();
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Serilog sink that writes events to Azure EventHubs
 
-##Usage
+## Usage
 
 ```csharp
 var eventHubClient = EventHubClient.CreateFromConnectionString(eventHubConnectionString, "entityPath");
@@ -12,8 +12,6 @@ var logger = new LoggerConfiguration()
                 .WriteTo.Sink(new AzureEventHubSink(
                     eventHubClient: eventHubClient,
                     formatter: new JsonFormatter()
-                    )
-				...
-				.CreateLogger();
-					
+                ...
+                .CreateLogger();
 ```

--- a/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubBatchingSink.cs
@@ -27,8 +27,6 @@ namespace Collector.Serilog.Sinks.AzureEventHub
 
         readonly EventHubClient _eventHubClient;
         readonly ITextFormatter _formatter;
-        private readonly string _applicationName;
-        readonly Action<EventData, LogEvent> _eventDataAction;
 
         /// <summary>
         /// Construct a sink that saves log events to the specified EventHubClient.
@@ -58,8 +56,6 @@ namespace Collector.Serilog.Sinks.AzureEventHub
 
             _eventHubClient = eventHubClient;
             _formatter = formatter;
-            _applicationName = applicationName;
-            _eventDataAction = eventDataAction;
         }
 
         /// <summary>
@@ -119,14 +115,8 @@ namespace Collector.Serilog.Sinks.AzureEventHub
             };
 
             eventHubData = eventHubData.AsCompressed();
-            if (!string.IsNullOrWhiteSpace(_applicationName) && !eventHubData.Properties.ContainsKey("Type"))
-            {
-                eventHubData.Properties.Add("Type", _applicationName);
-            }
 
             eventHubData.Properties.Add("LogItemId", Guid.NewGuid().ToString());
-            
-            _eventDataAction?.Invoke(eventHubData, logEvent);
             return eventHubData;
         }
 

--- a/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubSink.cs
+++ b/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubSink.cs
@@ -21,9 +21,7 @@ namespace Collector.Serilog.Sinks.AzureEventHub
     public class AzureEventHubSink : ILogEventSink
     {
         private readonly EventHubClient _eventHubClient;
-        private readonly string _applicationName;
         private readonly ITextFormatter _formatter;
-        private readonly Action<EventData, LogEvent> _eventDataAction;
 #if NET45
         private readonly int? _compressionTreshold;
 #endif
@@ -49,9 +47,7 @@ namespace Collector.Serilog.Sinks.AzureEventHub
             )
         {
             _eventHubClient = eventHubClient;
-            _applicationName = applicationName;
             _formatter = formatter ?? new ScalarValueTypeSuffixJsonFormatter();
-            _eventDataAction = eventDataAction;
 #if NET45
             _compressionTreshold = compressionTreshold;
 #endif
@@ -77,16 +73,8 @@ namespace Collector.Serilog.Sinks.AzureEventHub
                 PartitionKey = Guid.NewGuid().ToString()
 #endif
             };
-            _eventDataAction?.Invoke(eventHubData, logEvent);
-            if (!string.IsNullOrWhiteSpace(_applicationName) && !eventHubData.Properties.ContainsKey("Type"))
-            {
-                eventHubData.Properties.Add("Type", _applicationName);
-            }
-
             eventHubData.Properties.Add("LogItemId", Guid.NewGuid().ToString());
-            
 #if NET45
-
             if (_compressionTreshold != null && eventHubData.SerializedSizeInBytes > _compressionTreshold)
                 eventHubData = eventHubData.AsCompressed();
 

--- a/src/Collector.Serilog.Sinks.AzureEventHub/Collector.Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Collector.Serilog.Sinks.AzureEventHub/Collector.Serilog.Sinks.AzureEventHub.csproj
@@ -6,7 +6,7 @@
     <DebugType>portable</DebugType>
     <AssemblyName>Collector.Serilog.Sinks.AzureEventHub</AssemblyName>
     <PackageId>Collector.Serilog.Sinks.AzureEventHub</PackageId>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <Description>Serilog sink that writes to Azure Event Hub.</Description>
     <Copyright>Copyright © 2017</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -17,6 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/collector-bank/serilog-sinks-azureeventhub</RepositoryUrl>
     <PackageProjectUrl>https://github.com/collector-bank/serilog-sinks-azureeventhub</PackageProjectUrl>
+    <PackageReleaseNotes>Removed type and application_name from constructor. Instead of using those, use enrichers to make difference between different logging sources.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed type and application name.
Bumped to version 2.0.0 since the constructor was changed. 

Which formatter do we want as standard for the constructor? Does it matter?
