### PR TITLE
Send event only once for net45

### DIFF
--- a/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Collector.Serilog.Sinks.AzureEventHub/AzureEventHubBatchingSink.cs
@@ -136,8 +136,9 @@ namespace Collector.Serilog.Sinks.AzureEventHub
                     {
                         _eventHubClient.Send(eventData);
                     }
-#endif
+#else
                     _eventHubClient.SendAsync(eventData).Wait();
+#endif
                 }
                 catch
                 {


### PR DESCRIPTION
Note that I haven't tested this myself, but the logic seem strange. What do you think?

This kind of check is included for `AzureEventHubSink` and also found in `AzureEventHubBatchingSink` method `SendBatchAsOneChunk`.